### PR TITLE
Fix batching in HCFStates._hcf_fetch.

### DIFF
--- a/hcf_backend/__init__.py
+++ b/hcf_backend/__init__.py
@@ -65,11 +65,14 @@ class HCFStates(MemoryStates):
             while True:
                 try:
                     prepared_keys.append("key=%s" % i.next())
-                    if len(prepared_keys) > 32:
+                    if len(prepared_keys) >= 32:
                         break
                 except StopIteration:
                     finished = True
                     break
+
+            if not prepared_keys:
+                break
 
             prepared_keys.append("meta=_key")
             params = {'method':'GET',


### PR DESCRIPTION
Split by 32 items instead of 33 and fix empty batches which would
retrieve the entire collection.