### PR TITLE
Allow to override components by a setting.

### DIFF
--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -2,13 +2,14 @@
 import config
 from hcf_backend import HCFQueue
 from frontera.core.models import Request
+from frontera.contrib.backends.partitioners import FingerprintPartitioner
 from time import sleep
 import logging
 
 
 def test_queue():
     logging.basicConfig(level=logging.DEBUG)
-    queue = HCFQueue(config.API_KEY, config.PROJECT_ID, config.FRONTIER_NAME, 10000, 1, 1, "", True)
+    queue = HCFQueue(config.API_KEY, config.PROJECT_ID, config.FRONTIER_NAME, 10000, 1, 1, "", True, FingerprintPartitioner)
 
     queue.frontier_start()
 


### PR DESCRIPTION
This improves extensibility and allows to customize the Queue, States
and Partitioner instances used by the HCF backend.